### PR TITLE
Add pc build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,122 @@
+cmake_minimum_required (VERSION 2.8.2)
+project (neographics)
+
+###################################################################
+# Dependencies
+###################################################################
+
+include(ExternalProject)
+ExternalProject_Add(
+	stb
+	GIT_REPOSITORY https://github.com/nothings/stb.git
+	GIT_TAG master
+	PREFIX ${CMAKE_CURRENT_BINARY_DIR}/stb
+	CONFIGURE_COMMAND ""
+	BUILD_COMMAND ""
+	INSTALL_COMMAND ""
+)
+ExternalProject_Get_Property(stb source_dir)
+set(STB_SOURCE_DIR ${source_dir})
+
+###################################################################
+# Utilities
+###################################################################
+
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG ${CMAKE_BINARY_DIR}/bin)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR}/bin)
+
+function(assign_source_group)
+    foreach(_source IN ITEMS ${ARGN})
+        if (IS_ABSOLUTE "${_source}")
+            file(RELATIVE_PATH _source_rel "${CMAKE_CURRENT_SOURCE_DIR}" "${_source}")
+        else()
+            set(_source_rel "${_source}")
+        endif()
+        get_filename_component(_source_path "${_source_rel}" PATH)
+        string(REPLACE "/" "\\" _source_path_msvc "${_source_path}")
+        source_group("${_source_path_msvc}" FILES "${_source}")
+    endforeach()
+endfunction(assign_source_group)
+
+###################################################################
+# neographics
+###################################################################
+
+set(sources_neographics
+  src/draw_command/draw_command.c
+  src/draw_command/draw_command.h
+  src/fonts/fonts.c
+  src/fonts/fonts.h
+  src/path/path.c
+  src/path/path.h
+  src/primitives/circle.c
+  src/primitives/circle.h
+  src/primitives/line.c
+  src/primitives/line.h
+  src/primitives/rect.c
+  src/primitives/rect.h
+  src/text/text.c
+  src/text/text.h
+  src/types/color.h
+  src/types/colors.h
+  src/types/cornermask.h
+  src/types/point.h
+  src/types/rect.c
+  src/types/rect.h
+  src/types/size.h
+  src/common.c
+  src/common.h
+  src/context.c
+  src/context.h
+  src/graphics.h
+  src/macros.h
+  src/types.h
+
+  contrib/pebble_env/pebble.c
+  contrib/pebble_env/pebble.h
+)
+assign_source_group(${sources_neographics})
+
+add_definitions(-DNGFX_IS_CORE)
+include_directories("contrib/pebble_env")
+if (NOT WIN32)
+    link_libraries(m) # everyone needs a bit of math (except windows)
+endif()
+
+add_library(neographics_rect ${sources_neographics} )
+target_compile_definitions(neographics_rect PUBLIC PBL_RECT=1)
+
+add_library(neographics_rect_bw ${sources_neographics} )
+target_compile_definitions(neographics_rect_bw PUBLIC PBL_RECT=1 PBL_BW=1)
+
+add_library(neographics_round ${sources_neographics} )
+target_compile_definitions(neographics_round PUBLIC)
+
+###################################################################
+# tests
+###################################################################
+
+set(sources_test_neographics
+    contrib/test/testrunner.c
+    contrib/test/stb_impl.c
+)
+assign_source_group(${sources_test_neographics})
+
+add_executable(test_neographics_rect ${sources_test_neographics} )
+target_link_libraries(test_neographics_rect neographics_rect)
+target_compile_definitions(neographics_rect PUBLIC PBL_TYPE=rect PBL_RECT=1)
+target_include_directories(neographics_rect PUBLIC "src" ${STB_SOURCE_DIR})
+add_dependencies(neographics_rect stb)
+
+add_executable(test_neographics_rect_bw ${sources_test_neographics} )
+target_link_libraries(test_neographics_rect_bw neographics_rect_bw)
+target_compile_definitions(neographics_rect_bw PUBLIC PBL_TYPE=rect_bw PBL_RECT=1 PBL_BW=1)
+target_include_directories(neographics_rect_bw PUBLIC "src" ${STB_SOURCE_DIR})
+add_dependencies(neographics_rect_bw stb)
+
+add_executable(test_neographics_round ${sources_test_neographics} )
+target_link_libraries(test_neographics_round neographics_round)
+target_compile_definitions(neographics_round PUBLIC PBL_TYPE=round)
+target_include_directories(neographics_round PUBLIC "src" ${STB_SOURCE_DIR})
+add_dependencies(neographics_round stb)

--- a/contrib/pebble_env/pebble.c
+++ b/contrib/pebble_env/pebble.c
@@ -1,0 +1,15 @@
+#include "pebble.h"
+
+#include <math.h>
+
+static const double _2PI = 2 * 3.141592653;
+
+int32_t sin_lookup(int32_t angle) {
+    double fangle = ((double)angle) / TRIG_MAX_ANGLE * _2PI;
+    return (int32_t)(sin(fangle) * TRIG_MAX_RATIO);
+}
+
+int32_t cos_lookup(int32_t angle) {
+    double fangle = ((double)angle) / TRIG_MAX_ANGLE * _2PI;
+    return (int32_t)(cos(fangle) * TRIG_MAX_RATIO);
+}

--- a/contrib/pebble_env/pebble.h
+++ b/contrib/pebble_env/pebble.h
@@ -1,0 +1,77 @@
+#ifndef _PEBBLE_H
+#define _PEBBLE_H
+/* enough emulation to run neographics locally, except math
+ * all functions are expected to be defined in the importing
+ * project (e.g. test_neographics_rect)
+ */
+
+#include <stdio.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+#include <inttypes.h>
+
+// Math
+
+#define TRIG_MAX_RATIO 0xffff
+#define TRIG_MAX_ANGLE 0x10000
+
+int32_t sin_lookup(int32_t angle);
+int32_t cos_lookup(int32_t angle);
+
+// Resource
+typedef void* ResHandle;
+
+size_t resource_size(ResHandle handle);
+ResHandle resource_get_handle(uint32_t id);
+size_t resource_load(ResHandle h, uint8_t * buffer, size_t max_length);
+
+// GBitmap
+
+typedef enum GAlign
+{
+	GAlignCenter,
+	GAlignTopLeft,
+	GAlignTopRight,
+	GAlignTop,
+	GAlignLeft,
+	GAlignBottom,
+	GAlignRight,
+	GAlignBottomRight,
+	GAlignBottomLeft
+} GAlign;
+
+
+typedef enum GCompOp {
+	GCompOpAssign = 0,
+	GCompOpAssignInverted,
+	GCompOpOr,
+	GCompOpAnd,
+	GCompOpClear,
+	GCompOpSet
+} GCompOp;
+
+typedef enum GBitmapFormat {
+	GBitmapFormat1Bit = 0,
+	GBitmapFormat8Bit,
+	GBitmapFormat1BitPalette,
+	GBitmapFormat2BitPalette,
+	GBitmapFormat4BitPalette,
+} GBitmapFormat;
+
+struct GBitmap {
+	int dummy;
+};
+
+typedef struct GBitmap GBitmap;
+
+// Framebuffer
+
+struct n_GContext;
+
+GBitmap * graphics_capture_frame_buffer(struct n_GContext * ctx);
+GBitmap * graphics_capture_frame_buffer_format(struct n_GContext * ctx, GBitmapFormat format);
+bool graphics_release_frame_buffer(struct n_GContext * ctx, GBitmap * bitmap);
+
+#endif

--- a/contrib/test/stb_impl.c
+++ b/contrib/test/stb_impl.c
@@ -1,0 +1,10 @@
+// All implementations of stb
+
+#define _CRT_SECURE_NO_WARNINGS // to quiet msvc
+
+#define STB_IMAGE_IMPLEMENTATION
+#define STBI_NO_SIMD // SIMD build crashes clang on windows
+#include <stb_image.h>
+
+#define STB_IMAGE_WRITE_IMPLEMENTATION
+#include <stb_image_write.h>

--- a/contrib/test/testrunner.c
+++ b/contrib/test/testrunner.c
@@ -1,0 +1,84 @@
+/*
+ * The first draft of the test runner, currently without any unit tests
+ */
+#include <graphics.h>
+
+#include <stb_image.h>
+#include <stb_image_write.h>
+
+#define _MACRO_STR_VALUE(arg) #arg
+#define MACRO_STR_VALUE(arg) _MACRO_STR_VALUE(arg)
+#define OUTPUT_FILENAME ("output_" MACRO_STR_VALUE(PBL_TYPE) ".png")
+
+void saveFramebufferToPNG(n_GContext* ctx, const char* filename) {
+	static uint8_t color_framebuffer[__SCREEN_WIDTH * __SCREEN_HEIGHT * 4]; // ugly, but hey we are on PC now
+	uint8_t* outColorPtr = color_framebuffer;
+
+#ifdef PBL_BW
+	uint8_t* fbColorPtr, *fbLinePtr = ctx->fbuf;
+	for (uint32_t y = 0; y < __SCREEN_HEIGHT; y++) {
+		fbColorPtr = fbLinePtr;
+		for (uint32_t x = 0; x < __SCREEN_WIDTH / 8; x++) {
+			for (int i = 0; i < 8; i++) {
+				uint8_t val = (*fbColorPtr & (1 << i)) ? 255 : 0;
+				outColorPtr[0] = outColorPtr[1] = outColorPtr[2] = val;
+				outColorPtr[3] = 255;
+				outColorPtr += 4;
+			}
+			fbColorPtr += 1;
+		}
+		fbLinePtr += __SCREEN_FRAMEBUFFER_ROW_BYTE_AMOUNT;
+	}
+#else
+	uint32_t byteCount = __SCREEN_FRAMEBUFFER_ROW_BYTE_AMOUNT * __SCREEN_HEIGHT;
+	n_GColor* fbColorPtr = (n_GColor*)ctx->fbuf;
+	while (--byteCount) {
+		outColorPtr[0] = fbColorPtr->r * 85;
+		outColorPtr[1] = fbColorPtr->g * 85;
+		outColorPtr[2] = fbColorPtr->b * 85;
+		outColorPtr[3] = fbColorPtr->a * 85;
+		fbColorPtr += 1;
+		outColorPtr += 4;
+	}
+#endif
+
+	stbi_write_png(filename, __SCREEN_WIDTH, __SCREEN_HEIGHT, 4, color_framebuffer, __SCREEN_WIDTH * 4);
+}
+
+// Stubs to not anger the linker anymore
+GBitmap* graphics_capture_frame_buffer(n_GContext* ctx) {
+	return NULL;
+}
+
+GBitmap* graphics_capture_frame_buffer_format(n_GContext* ctx, GBitmapFormat format) {
+	return NULL;
+}
+
+bool graphics_release_frame_buffer(n_GContext* ctx, GBitmap* bitmap) {
+	return false;
+}
+
+int main(int argc, char* argv[]) {
+	uint8_t* framebuffer = (uint8_t*)malloc(__SCREEN_FRAMEBUFFER_ROW_BYTE_AMOUNT * __SCREEN_HEIGHT);
+	if (framebuffer == NULL) {
+		fprintf(stderr, "Could not allocate framebuffer\n");
+		return 1;
+	}
+	n_GContext* ctx = n_graphics_context_from_buffer(framebuffer);
+	if (ctx == NULL) {
+		fprintf(stderr, "Could not create context\n");
+		return 1;
+	}
+
+	// create a test output
+	uint16_t w = __SCREEN_WIDTH, h = __SCREEN_HEIGHT;
+	n_graphics_context_set_fill_color(ctx, n_GColorBlack);
+	n_graphics_fill_rect(ctx, n_GRect(0, 0, w, h), 0, n_GCornerNone);
+	n_graphics_context_set_fill_color(ctx, n_GColorRed);
+	n_graphics_fill_rect(ctx, n_GRect(w / 4, h / 4, w / 2, h / 2), 0, n_GCornerNone);
+	saveFramebufferToPNG(ctx, OUTPUT_FILENAME);
+
+	n_graphics_context_destroy(ctx);
+	free(framebuffer);
+	return 0;
+}


### PR DESCRIPTION
So this is the first iteration of a build infrastructure for PCs as discussed, but there a few notes to be made:

- It does not contain a test runner yet (only a dummy test application)
- It adds a dependency to nothings/stb but it is being resolved by CMake automatically
- There are 8 external functions needed to build neographics, except from the two trivial math functions, these are currently expected to be implemented by the test runner
- Sadly because of C flexible array members this will not build on the Microsoft C Compiler, alternatively one can install the Clang toolset for VS and use `cmake -T v141_clang_c2` which does work.

I have thought about adding a graphical test application, but that would require a dependency to a cross-platform graphics library (e.g. SDL) which cannot be resolved automatically (although CMake has a somewhat support for finding SDL)

For the test runner we could write one of our own in case we want to run the tests on hardware (but what about the many resources then?) or use something like googletest which would be easy to add via CMake but prevents us from running the tests on hw.