### PR TITLE
Fix bitorder

### DIFF
--- a/contrib/testrunner_pc/resources.c
+++ b/contrib/testrunner_pc/resources.c
@@ -268,6 +268,10 @@ n_GBitmap *convert8BitImage(n_GBitmap *source, n_GBitmapFormat format) {
         case n_GBitmapFormat1Bit: bits_per_pixel = 1; break;
         default: return NULL;
     }
+    uint32_t pixels_per_byte = 8 / bits_per_pixel;
+    int32_t offset_in_byte = format == n_GBitmapFormat1Bit
+        ? 0 // everything except 1Bit is msb->lsb
+        : pixels_per_byte - 1;
 
     uint32_t w = source->raw_bitmap_size.w;
     uint32_t h = source->raw_bitmap_size.h;
@@ -307,9 +311,9 @@ n_GBitmap *convert8BitImage(n_GBitmap *source, n_GBitmapFormat format) {
                 }
             }
 
-            uint32_t byte_index = y * pitch + x / (8 / bits_per_pixel);
+            uint32_t byte_index = y * pitch + x / pixels_per_byte;
             uint32_t mask = (1 << bits_per_pixel) - 1;
-            uint32_t shift = (x % (8 / bits_per_pixel)) * bits_per_pixel;
+            uint32_t shift = abs(offset_in_byte - x % pixels_per_byte) * bits_per_pixel;
             res->addr[byte_index] |= (nearest & mask) << shift;
         }
     }

--- a/src/gbitmap/blit_bw.c
+++ b/src/gbitmap/blit_bw.c
@@ -49,6 +49,9 @@ void n_graphics_blit_alpha(struct n_GContext *ctx, const n_GBitmap *bitmap,
     uint8_t bits_per_pixel = n_gbitmapformat_get_bits_per_pixel(bitmap->format);
     uint8_t index_mask = (1 << bits_per_pixel) - 1;
     uint8_t pixels_per_byte = 8 / bits_per_pixel;
+    int offset_in_byte = bitmap->format == n_GBitmapFormat1Bit
+        ? 0
+        : pixels_per_byte - 1;
 
     for (int y = 0; y < bounds.size.h; y++) {
         for (int x = 0; x < bounds.size.w; x++) {
@@ -62,7 +65,7 @@ void n_graphics_blit_alpha(struct n_GContext *ctx, const n_GBitmap *bitmap,
             int src_x = bitmap->bounds.origin.x + (src_offset.x + x) % bitmap->bounds.size.w;
             int src_y = bitmap->bounds.origin.y + (src_offset.y + y) % bitmap->bounds.size.h;
             int src_byte = bitmap->addr[src_y * bitmap->row_size_bytes + src_x / pixels_per_byte];
-            int src_bit = (src_x % pixels_per_byte) * bits_per_pixel;
+            int src_bit = abs(offset_in_byte - src_x % pixels_per_byte) * bits_per_pixel;
             int src_index = (src_byte >> src_bit) & index_mask;
             int src_color = color_palette >> src_index;
             int src_alpha = alpha_palette >> src_index;

--- a/src/gbitmap/blit_color.c
+++ b/src/gbitmap/blit_color.c
@@ -81,9 +81,11 @@ void n_graphics_blit_palette(struct n_GContext *ctx, const n_GBitmap *bitmap,
     uint8_t bits_per_pixel = n_gbitmapformat_get_bits_per_pixel(bitmap->format);
     uint8_t index_mask = (1 << bits_per_pixel) - 1;
     uint8_t pixels_per_byte = 8 / bits_per_pixel;
+    int offset_in_byte = pixels_per_byte - 1;
     const n_GColor* palette = bitmap->palette;
     if (bitmap->format == n_GBitmapFormat1Bit) {
         palette = (const n_GColor*)bw_palettes[ctx->comp_op];
+        offset_in_byte = 0;
     }
 
     // Blit the bitmap
@@ -100,7 +102,7 @@ void n_graphics_blit_palette(struct n_GContext *ctx, const n_GBitmap *bitmap,
         for (int x = 0; x < bounds.size.w; x++) {
             int src_x = bitmap->bounds.origin.x + (src_offset.x + x) % bitmap->bounds.size.w;
             uint8_t src_pixel_byte = bm_line[src_x / pixels_per_byte];
-            int src_pixel_bit = (src_x % pixels_per_byte) * bits_per_pixel;
+            int src_pixel_bit = abs(offset_in_byte - src_x % pixels_per_byte) * bits_per_pixel;
             int src_color_index = (src_pixel_byte >> src_pixel_bit) & index_mask;
             n_GColor src_color = palette[src_color_index];
 

--- a/test/test_test.h
+++ b/test/test_test.h
@@ -150,10 +150,10 @@ NGFX_TEST(Test, LoadImage,
     {
         ngfxtest_load_image_ex(checker, 1, n_GBitmapFormat4BitPalette);
         n_GColor colors[4] = {
-            checker->palette[checker->addr[0] & 15],
             checker->palette[checker->addr[0] >> 4],
-            checker->palette[checker->addr[1] & 15],
-            checker->palette[checker->addr[1] >> 4]
+            checker->palette[checker->addr[0] & 15],
+            checker->palette[checker->addr[1] >> 4],
+            checker->palette[checker->addr[1] & 15]
         };
 
         NGFX_ASSERT_EQ(checker->format, n_GBitmapFormat4BitPalette);
@@ -165,10 +165,10 @@ NGFX_TEST(Test, LoadImage,
     {
         ngfxtest_load_image_ex(checker, 1, n_GBitmapFormat2BitPalette);
         n_GColor colors[4] = {
-            checker->palette[(checker->addr[0] >> 0) & 3],
-            checker->palette[(checker->addr[0] >> 2) & 3],
-            checker->palette[(checker->addr[1] >> 0) & 3],
-            checker->palette[(checker->addr[1] >> 2) & 3]
+            checker->palette[(checker->addr[0] >> 6) & 3],
+            checker->palette[(checker->addr[0] >> 4) & 3],
+            checker->palette[(checker->addr[1] >> 6) & 3],
+            checker->palette[(checker->addr[1] >> 4) & 3]
         };
 
         NGFX_ASSERT_EQ(checker->format, n_GBitmapFormat2BitPalette);
@@ -180,10 +180,10 @@ NGFX_TEST(Test, LoadImage,
     {
         ngfxtest_load_image_ex(checker, 1, n_GBitmapFormat1BitPalette);
         n_GColor colors[4] = {
-            checker->palette[(checker->addr[0] >> 0) & 1],
-            checker->palette[(checker->addr[0] >> 1) & 1],
-            checker->palette[(checker->addr[1] >> 0) & 1],
-            checker->palette[(checker->addr[1] >> 1) & 1]
+            checker->palette[(checker->addr[0] >> 7) & 1],
+            checker->palette[(checker->addr[0] >> 6) & 1],
+            checker->palette[(checker->addr[1] >> 7) & 1],
+            checker->palette[(checker->addr[1] >> 6) & 1]
         };
 
         NGFX_ASSERT_EQ(checker->format, n_GBitmapFormat1BitPalette);
@@ -194,9 +194,11 @@ NGFX_TEST(Test, LoadImage,
     }
     {
         ngfxtest_load_image_ex(checker, 1, n_GBitmapFormat1Bit);
+        int pitch = checker->row_size_bytes;
 
+        // remember: 1Bit is lsb->msb
         NGFX_ASSERT_EQ(checker->format, n_GBitmapFormat1Bit);
-        NGFX_ASSERT_EQ(checker->addr[0] & 3, 0b01);
-        NGFX_ASSERT_EQ(checker->addr[1] & 3, 0b00);
+        NGFX_ASSERT_EQ(checker->addr[pitch * 0] & 3, 0b01);
+        NGFX_ASSERT_EQ(checker->addr[pitch * 1] & 3, 0b00);
     }
 )


### PR DESCRIPTION
I assumed PebbleOS uses lsb->msb bitorder for all bitmaps, turns out only 

- 1Bit bitmaps
- black/white framebuffer and
- old-style (1Bit) PBI files

use it, everything else is msb->lsb. This PR should fix this for ngfx